### PR TITLE
add basic packaging with Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,3 +18,5 @@ coverage.xml
 *.log
 .git
 build
+compose
+docker-compose.yml

--- a/.editorconfig
+++ b/.editorconfig
@@ -19,3 +19,7 @@ indent_size=2
 [*.ini]
 indent_style=space
 indent_size=4
+
+[*.sh]
+indent_style=space
+indent_size=4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.6
+
+WORKDIR /usr/src/app
+
+ADD ./requirements*.txt /usr/src/app/
+RUN pip install -r ./requirements_docker.txt
+
+ADD ./ /usr/src/app/
+
+ENV DJANGO_SETTINGS_MODULE=lookupproxy.settings.docker
+ENTRYPOINT ["scripts/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ details.
 ## Dockerfile
 
 This application ships with a basic packaging using Docker. It makes use of
-[whitenoise](http://whitenoise.evans.io/en/stable/) to serve static files. The
+[gunicorn](http://gunicorn.org/) to serve the docker application and, via
+[whitenoise](http://whitenoise.evans.io/en/stable/), to serve static files. The
 container is configured to use lookupproxy.settings.docker by default as the
 Django settings. In use you probably want to override this with a settings
 module which includes at least the OAuth2 configuration and SECRET_KEY setting.

--- a/README.md
+++ b/README.md
@@ -11,3 +11,11 @@ for clients outside of the CUDN.
 Clients are authorised by means of an OAuth2 token with appropriate scope. See
 [the documentation](https://uisautomation.github.io/lookupproxy) for further
 details.
+
+## Dockerfile
+
+This application ships with a basic packaging using Docker. It makes use of
+[whitenoise](http://whitenoise.evans.io/en/stable/) to serve static files. The
+container is configured to use lookupproxy.settings.docker by default as the
+Django settings. In use you probably want to override this with a settings
+module which includes at least the OAuth2 configuration and SECRET_KEY setting.

--- a/lookupproxy/settings/docker.py
+++ b/lookupproxy/settings/docker.py
@@ -1,0 +1,10 @@
+from .base import *  # noqa: F403
+
+DEBUG = False
+ALLOWED_HOSTS = ['*']
+
+STATIC_ROOT = '/usr/src/app/build/static'
+
+MIDDLEWARE = [
+    'whitenoise.middleware.WhiteNoiseMiddleware',
+] + MIDDLEWARE  # noqa: F405

--- a/requirements_docker.txt
+++ b/requirements_docker.txt
@@ -1,0 +1,6 @@
+# include base requirements
+-r ./requirements.txt
+
+# additional requirements for Docker container
+gunicorn
+whitenoise

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+python manage.py migrate                  # Apply database migrations
+python manage.py collectstatic --noinput  # Collect static files
+
+# Start Gunicorn processes
+echo Starting Gunicorn.
+exec gunicorn lookupproxy.wsgi:application \
+    --name lookupproxy \
+    --bind 0.0.0.0:8080 \
+    --workers 3 \
+    --log-level=info \
+    --log-file=- \
+    --access-logfile=- \
+    "$@"


### PR DESCRIPTION
Add Dockerfile and associated configuration for a basic containerised
deployment. The container uses a new settings module,
lookupproxy.settings.docker. This uses whitenoise[1] to serve static
files, disables debug and allows all hosts. Add a docker entrypoint
which collects the static files and then serves the application via
gunicorn.

[1] http://whitenoise.evans.io/en/stable/

Required for https://github.com/uisautomation/usvc-ansible/issues/1