### PR TITLE
allow listing institutions

### DIFF
--- a/lookupapi/serializers.py
+++ b/lookupapi/serializers.py
@@ -18,9 +18,10 @@ class Base64Field(serializers.Field):
 
 class FetchParametersSerializer(serializers.Serializer):
     """Serialise fetch parameters from a query string."""
-    fetch = serializers.CharField(default='', help_text=(
+    fetch = serializers.CharField(default=None, help_text=(
         'Comma-separated list of additional data to fetch for the resource. See '
-        'https://www.lookup.cam.ac.uk/doc/ws-pydocs3/ibisclient.methods.PersonMethods.html '
+        'https://www.lookup.cam.ac.uk/doc/ws-pydocs3/ibisclient.methods.PersonMethods.html and '
+        'https://www.lookup.cam.ac.uk/doc/ws-pydocs3/ibisclient.methods.InstitutionMethods.html '
         'for details on the values this parameter can take.'))
 
 
@@ -54,6 +55,12 @@ class SearchParametersSerializer(FetchParametersSerializer):
         default='surname',
         choices=[('identifier', 'Primary Identifier'), ('surname', 'Surname')],
         help_text='The order in which to list the results. The default is "surname".')
+
+
+class InstitutionListParametersSerializer(FetchParametersSerializer):
+    """Serialise parameters the for the institution list endpoing."""
+    includeCancelled = serializers.BooleanField(default=False, help_text=(
+        'Flag to allow cancelled institutions. By default, only live institutions are returned.'))
 
 
 class AttributeSchemeSerializer(serializers.Serializer):

--- a/lookupapi/urls.py
+++ b/lookupapi/urls.py
@@ -61,6 +61,7 @@ urlpatterns = [
 
     path('groups/<groupid>', views.Group.as_view(), name='group-detail'),
 
+    path('institutions', views.InstitutionList.as_view(), name='institution-list'),
     path('institutions/<instid>', views.Institution.as_view(), name='institution-detail'),
     path('attributes/institutions', views.InstitutionFetchAttributes.as_view(),
          name='institution-attributes'),

--- a/lookupapi/urls.py
+++ b/lookupapi/urls.py
@@ -56,7 +56,7 @@ can use this in your URL config to render a Swagger UI for the API:
 
 urlpatterns = [
     path('attributes/people', views.PersonFetchAttributes.as_view(), name='person-attributes'),
-    path('search', views.PersonSearch.as_view(), name='person-search'),
+    path('people', views.PersonSearch.as_view(), name='person-search'),
     path('people/crsid/<crsid>', views.PersonByCRSID.as_view(), name='crsid-person-detail'),
 
     path('groups/<groupid>', views.Group.as_view(), name='group-detail'),


### PR DESCRIPTION
880e925 adds a new /institutions endpoint which lists institutions known to lookup. In order to improve consistency, e7ddf1b renames the existing /search endpoint to /people since it also returns a list of resources known to lookup.