### PR TITLE
misc correctness fixes

### DIFF
--- a/lookupapi/serializers.py
+++ b/lookupapi/serializers.py
@@ -337,6 +337,11 @@ class AttributeSchemeListSerializer(serializers.Serializer):
     results = AttributeSchemeSerializer(many=True, help_text="List of attribute schemes")
 
 
+class InstitutionListResultsSerializer(serializers.Serializer):
+    """Serializer for person list results."""
+    results = InstitutionSummarySerializer(many=True, help_text='Results of search')
+
+
 class HealthSerializer(serializers.Serializer):
     """
     Health check response.

--- a/lookupapi/serializers.py
+++ b/lookupapi/serializers.py
@@ -92,18 +92,14 @@ class AttributeSchemeSerializer(serializers.Serializer):
 class PersonHyperlink(serializers.HyperlinkedIdentityField):
     """A field which can construct the appropriate link to a Person resource."""
     def get_url(self, obj, view_name, request, format):
-        # We can only link to people identified by CRSid.
-        if obj.identifier.scheme != 'crsid':
-            return None
-
-        url_kwargs = {'crsid': obj.identifier.value}
+        url_kwargs = {'identifier': obj.identifier.value, 'scheme': obj.identifier.scheme}
         return reverse(view_name, kwargs=url_kwargs, request=request, format=format)
 
 
 class PersonHyperlinkSerializer(serializers.Serializer):
     """Hyperlink-only serializer for IbisPerson objects."""
     url = PersonHyperlink(
-        view_name='crsid-person-detail', help_text='Link to full resource.')
+        view_name='person-detail', help_text='Link to full resource.')
 
 
 class GroupHyperlinkSerializer(serializers.Serializer):

--- a/lookupapi/serializers.py
+++ b/lookupapi/serializers.py
@@ -324,8 +324,8 @@ class PersonSerializer(PersonSummarySerializer):
     surname = serializers.CharField(help_text='The person\'s surname (if visible).')
 
 
-class PersonSearchResultsSerializer(serializers.Serializer):
-    """Serializer for search results."""
+class PersonListResultsSerializer(serializers.Serializer):
+    """Serializer for person list results."""
     results = PersonSummarySerializer(many=True, help_text='Results of search')
     count = serializers.IntegerField(help_text='Total number of results available.')
     offset = serializers.IntegerField(help_text='0-based index of first result to return.')

--- a/lookupapi/test/test_views.py
+++ b/lookupapi/test/test_views.py
@@ -88,8 +88,8 @@ class AuthenticatedViewTestCase(ViewTestCase):
 
 
 class PersonByCRSIDTest(AuthenticatedViewTestCase, TestCase):
-    view_name = 'crsid-person-detail'
-    view_kwargs = {'crsid': 'spqr2'}
+    view_name = 'person-detail'
+    view_kwargs = {'scheme': 'crsid', 'identifier': 'spqr2'}
 
     def test_not_found(self):
         self.get_person_methods.return_value.getPerson.return_value = None

--- a/lookupapi/test/test_views.py
+++ b/lookupapi/test/test_views.py
@@ -110,8 +110,8 @@ class PersonByCRSIDTest(AuthenticatedViewTestCase, TestCase):
         return person
 
 
-class PersonSearchTest(AuthenticatedViewTestCase, TestCase):
-    view_name = 'person-search'
+class PersonListTest(AuthenticatedViewTestCase, TestCase):
+    view_name = 'person-list'
     default_query = {'query': 'xxx'}
 
     def setUp(self):

--- a/lookupapi/urls.py
+++ b/lookupapi/urls.py
@@ -57,7 +57,7 @@ can use this in your URL config to render a Swagger UI for the API:
 urlpatterns = [
     path('attributes/people', views.PersonFetchAttributes.as_view(), name='person-attributes'),
     path('people', views.PersonSearch.as_view(), name='person-search'),
-    path('people/crsid/<crsid>', views.PersonByCRSID.as_view(), name='crsid-person-detail'),
+    path('people/<scheme>/<identifier>', views.Person.as_view(), name='person-detail'),
 
     path('groups/<groupid>', views.Group.as_view(), name='group-detail'),
 

--- a/lookupapi/urls.py
+++ b/lookupapi/urls.py
@@ -56,7 +56,7 @@ can use this in your URL config to render a Swagger UI for the API:
 
 urlpatterns = [
     path('attributes/people', views.PersonFetchAttributes.as_view(), name='person-attributes'),
-    path('people', views.PersonSearch.as_view(), name='person-search'),
+    path('people', views.PersonList.as_view(), name='person-list'),
     path('people/<scheme>/<identifier>', views.Person.as_view(), name='person-detail'),
 
     path('groups/<groupid>', views.Group.as_view(), name='group-detail'),

--- a/lookupapi/views.py
+++ b/lookupapi/views.py
@@ -147,23 +147,14 @@ class InstitutionList(ViewPermissionsMixin, generics.ListAPIView):
     Return a list of all institutions known to Lookup.
 
     """
-    serializer_class = serializers.InstitutionSerializer
+    serializer_class = serializers.InstitutionListResultsSerializer
 
-    def get_queryset(self):
+    def list(self, request):
         query = serializers.InstitutionListParametersSerializer(self.request.query_params).data
-        return ibis.get_institution_methods().allInsts(
+        results = ibis.get_institution_methods().allInsts(
             includeCancelled=query['includeCancelled'], fetch=query['fetch'])
-
-    def paginate_queryset(self, queryset):
-        """
-        Overridden since this has to return non-None for the get_paginated_response method to be
-        called.
-
-        """
-        return queryset
-
-    def get_paginated_response(self, data):
-        return Response({'results': data})
+        return Response(self.serializer_class(
+            {'results': results}, context={'request': request}).data)
 
 
 @method_decorator(name='get', decorator=swagger_auto_schema(


### PR DESCRIPTION
This PR tidies up some gnarly edges to the API to make the experience a little more polished.

5417220 exposes the fact that "crsid" is but one scheme understood by lookup. (Albeit, the only one understood in practice.) This doesn't change any behaviour but parameterises the previously hard-corded /people/crsid/{crsid} endpoint to people/{scheme}/{identifier}. This has little practical effect now but opens the possibility of allowing test users in future.

67a0b41 tidies up the Swagger documentation for the /people endpoint by making it appear as "people_list" in the documentation and correctly using a serialiser to generate the response.

6b3aeba does the same with the institution list endpoint.