### PR TITLE
create self endpoint to get the getPerson information of the user logged in

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,5 +18,4 @@ coverage.xml
 *.log
 .git
 build
-compose
 docker-compose.yml

--- a/lookupapi/ibis.py
+++ b/lookupapi/ibis.py
@@ -6,7 +6,6 @@ import functools
 import inspect
 from django.conf import settings
 from rest_framework.exceptions import APIException
-
 from ucamlookup import ibisclient
 
 

--- a/lookupapi/test/test_authentication.py
+++ b/lookupapi/test/test_authentication.py
@@ -5,13 +5,12 @@ Test custom DRF authentication
 import datetime
 import json
 from unittest import mock
-
+from django.contrib.auth import get_user_model
 from django.http import HttpRequest
 from django.test import TestCase
-from oauthlib.oauth2 import TokenExpiredError
 from requests import Response
 from rest_framework.request import Request
-
+from oauthlib.oauth2 import TokenExpiredError
 from lookupapi import authentication
 
 
@@ -20,6 +19,7 @@ class OAuth2Test(TestCase):
     UNKNOWN_TOKEN = 'UNKNOWN_TOKEN'
     FUTURE_TOKEN = 'FUTURE_TOKEN'
     PAST_TOKEN = 'PAST_TOKEN'
+    NO_SUBJECT_TOKEN = 'NO_SUBJECT_TOKEN'
 
     def setUp(self):
         # Create an empty HTTP request
@@ -33,7 +33,20 @@ class OAuth2Test(TestCase):
     def test_good_token(self):
         """A request with a good token is authenticated."""
         self.set_token(OAuth2Test.GOOD_TOKEN)
-        with self.patch_session():
+        with self.patch_oauth2_session():
+            result = self.authenticate()
+        self.assertIsNotNone(result)
+        user, auth = result
+        self.assertIsNotNone(user)
+        self.assertIsInstance(auth, dict)
+
+        # user should exist
+        self.assertTrue(get_user_model().objects.filter(username='testing:test0001').exists())
+
+    def test_empty_subject(self):
+        """A request with a good token but no subject creates no user."""
+        self.set_token(OAuth2Test.NO_SUBJECT_TOKEN)
+        with self.patch_oauth2_session():
             result = self.authenticate()
         self.assertIsNotNone(result)
         user, auth = result
@@ -43,23 +56,43 @@ class OAuth2Test(TestCase):
     def test_unknown_token(self):
         """A request with an unknown token is not authenticated."""
         self.set_token(OAuth2Test.UNKNOWN_TOKEN)
-        with self.patch_session():
+        with self.patch_oauth2_session():
             result = self.authenticate()
         self.assertIsNone(result)
 
     def test_past_token(self):
         """A request with an past token is not authenticated."""
         self.set_token(OAuth2Test.PAST_TOKEN)
-        with self.patch_session():
+        with self.patch_oauth2_session():
             result = self.authenticate()
         self.assertIsNone(result)
 
     def test_future_token(self):
         """A request with an future token is not authenticated."""
         self.set_token(OAuth2Test.FUTURE_TOKEN)
-        with self.patch_session():
+        with self.patch_oauth2_session():
             result = self.authenticate()
         self.assertIsNone(result)
+
+    def test_expired_token(self):
+        """A request with an expired token results in the session being re-created."""
+        self.set_token(OAuth2Test.GOOD_TOKEN)
+
+        def mocked_request(*args, **kwargs):
+            """Mocked request function for first call which raises TokenExpiredError."""
+            raise TokenExpiredError
+
+        # Mock the internal cached session so that mocked_request() is called and then, if all is
+        # working, a new session is obtained via the session patched by patch_oauth2_session.
+        cached_session_patch = mock.patch('lookupapi.authentication._request.__session')
+
+        with cached_session_patch as cached_session, self.patch_oauth2_session():
+            cached_session.request.side_effect = mocked_request
+            result = self.authenticate()
+        self.assertIsNotNone(result)
+        user, auth = result
+        self.assertIsNotNone(user)
+        self.assertIsInstance(auth, dict)
 
     def authenticate(self):
         """Convenience method to authenticate self.request against self.auth."""
@@ -69,7 +102,7 @@ class OAuth2Test(TestCase):
         """Set the Bearer token for the request to *token*."""
         self.request.META['HTTP_AUTHORIZATION'] = 'Bearer ' + token
 
-    def patch_session(self):
+    def patch_oauth2_session(self):
         """Patch the internal request session used by the authenticator."""
         mock_request = mock.MagicMock()
 
@@ -83,13 +116,19 @@ class OAuth2Test(TestCase):
 
             if token == OAuth2Test.GOOD_TOKEN:
                 response._content = json.dumps(dict(
+                    sub='testing:test0001',
                     active=True, iat=_utc_now() - 1000, exp=_utc_now() + 1000)).encode('utf8')
             elif token == OAuth2Test.FUTURE_TOKEN:
                 response._content = json.dumps(dict(
+                    sub='testing:test0001',
                     active=True, iat=_utc_now() + 1000, exp=_utc_now() + 3000)).encode('utf8')
             elif token == OAuth2Test.PAST_TOKEN:
                 response._content = json.dumps(dict(
+                    sub='testing:test0001',
                     active=True, iat=_utc_now() - 3000, exp=_utc_now() - 1000)).encode('utf8')
+            elif token == OAuth2Test.NO_SUBJECT_TOKEN:
+                response._content = json.dumps(dict(
+                    active=True, iat=_utc_now() - 1000, exp=_utc_now() + 1000)).encode('utf8')
             elif token == OAuth2Test.UNKNOWN_TOKEN:
                 pass  # default response suffices
             else:
@@ -99,10 +138,11 @@ class OAuth2Test(TestCase):
 
         mock_request.side_effect = side_effect
 
+        # Mock OAuth2Session to return our session mock
         mock_get_session = mock.MagicMock()
         mock_get_session.return_value.request = mock_request
 
-        return mock.patch('lookupapi.authentication._get_session', mock_get_session)
+        return mock.patch('lookupapi.authentication.OAuth2Session', mock_get_session)
 
 
 def _utc_now():

--- a/lookupapi/test/test_views.py
+++ b/lookupapi/test/test_views.py
@@ -112,8 +112,44 @@ class PersonByCRSIDTest(AuthenticatedViewTestCase, TestCase):
         return person
 
 
+class PersonMockedTest(AuthenticatedViewTestCase, TestCase):
+    view_name = 'person-detail'
+    view_kwargs = {'scheme': 'mock', 'identifier': 'test0005'}
+
+    def test_found_staff(self):
+        self.view_kwargs['identifier'] = "test0005"
+        person = self.create_person()
+        self.get_person_methods.return_value.getPerson.return_value = person
+        response = self.get()
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        import sys
+        sys.stdout.write(str(data))
+        self.assertEqual(data['identifier']['value'], "test0005")
+        self.assertEqual(data['identifier']['scheme'], "mock")
+        self.assertTrue(data['isStaff'])
+
+    def test_found_no_staff(self):
+        self.view_kwargs['identifier'] = "test0405"
+        person = self.create_person()
+        self.get_person_methods.return_value.getPerson.return_value = person
+        response = self.get()
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data['identifier']['value'], "test0405")
+        self.assertEqual(data['identifier']['scheme'], "mock")
+        self.assertFalse(data['isStaff'])
+
+    def create_person(self):
+        person = ibisclient.IbisPerson()
+        person.displayName = 'Testing1'
+        person.identifier = ibisclient.IbisIdentifier({'scheme': 'crsid', 'value': 'mug99'})
+        person.identifier.value = 'mug99'
+        return person
+
+
 class PersonSelfTest(AuthenticatedViewTestCase, TestCase):
-    view_name = 'person-self'
+    view_name = 'person-token-self'
 
     def test_found(self):
         person = self.create_person()

--- a/lookupapi/test/test_views.py
+++ b/lookupapi/test/test_views.py
@@ -5,6 +5,7 @@ Test API views.
 import urllib.parse
 from unittest import mock
 
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
 from ucamlookup import ibisclient
@@ -58,7 +59,8 @@ class AuthenticatedViewTestCase(ViewTestCase):
         self.auth_patch = self.patch_authenticate()
         self.mock_authenticate = self.auth_patch.start()
         # By default, authentication succeeds
-        self.mock_authenticate.return_value = (None, {'scope': ' '.join(self.required_scopes)})
+        user = get_user_model().objects.create_user(username="mock:test0001")
+        self.mock_authenticate.return_value = (user, {'scope': ' '.join(self.required_scopes)})
 
     def tearDown(self):
         self.auth_patch.stop()
@@ -107,6 +109,24 @@ class PersonByCRSIDTest(AuthenticatedViewTestCase, TestCase):
         person = ibisclient.IbisPerson()
         person.displayName = 'Testing1'
         person.identifier = ibisclient.IbisIdentifier({'scheme': 'crsid', 'value': 'spqr2'})
+        return person
+
+
+class PersonSelfTest(AuthenticatedViewTestCase, TestCase):
+    view_name = 'person-self'
+
+    def test_found(self):
+        person = self.create_person()
+        self.get_person_methods.return_value.getPerson.return_value = person
+        response = self.get()
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data.get('displayName'), person.displayName)
+
+    def create_person(self):
+        person = ibisclient.IbisPerson()
+        person.displayName = 'Testing1'
+        person.identifier = ibisclient.IbisIdentifier({'scheme': 'crsid', 'value': 'test0001'})
         return person
 
 

--- a/lookupapi/test/test_views.py
+++ b/lookupapi/test/test_views.py
@@ -149,7 +149,8 @@ class PersonMockedTest(AuthenticatedViewTestCase, TestCase):
 
 
 class PersonSelfTest(AuthenticatedViewTestCase, TestCase):
-    view_name = 'person-token-self'
+    view_name = 'person-detail'
+    view_kwargs = {'scheme': 'token', 'identifier': 'self'}
 
     def test_found(self):
         person = self.create_person()

--- a/lookupapi/urls.py
+++ b/lookupapi/urls.py
@@ -57,7 +57,7 @@ can use this in your URL config to render a Swagger UI for the API:
 urlpatterns = [
     path('attributes/people', views.PersonFetchAttributes.as_view(), name='person-attributes'),
     path('people', views.PersonList.as_view(), name='person-list'),
-    path('people/self', views.PersonSelf.as_view(), name='person-self'),
+    path('people/token/self', views.PersonSelf.as_view(), name='person-token-self'),
     path('people/<scheme>/<identifier>', views.Person.as_view(), name='person-detail'),
 
     path('groups/<groupid>', views.Group.as_view(), name='group-detail'),

--- a/lookupapi/urls.py
+++ b/lookupapi/urls.py
@@ -57,6 +57,7 @@ can use this in your URL config to render a Swagger UI for the API:
 urlpatterns = [
     path('attributes/people', views.PersonFetchAttributes.as_view(), name='person-attributes'),
     path('people', views.PersonList.as_view(), name='person-list'),
+    path('people/self', views.PersonSelf.as_view(), name='person-self'),
     path('people/<scheme>/<identifier>', views.Person.as_view(), name='person-detail'),
 
     path('groups/<groupid>', views.Group.as_view(), name='group-detail'),

--- a/lookupapi/urls.py
+++ b/lookupapi/urls.py
@@ -57,7 +57,6 @@ can use this in your URL config to render a Swagger UI for the API:
 urlpatterns = [
     path('attributes/people', views.PersonFetchAttributes.as_view(), name='person-attributes'),
     path('people', views.PersonList.as_view(), name='person-list'),
-    path('people/token/self', views.PersonSelf.as_view(), name='person-token-self'),
     path('people/<scheme>/<identifier>', views.Person.as_view(), name='person-detail'),
 
     path('groups/<groupid>', views.Group.as_view(), name='group-detail'),

--- a/lookupapi/views.py
+++ b/lookupapi/views.py
@@ -132,7 +132,6 @@ class Person(ViewPermissionsMixin, generics.RetrieveAPIView):
         if scheme == "token" and identifier == "self":
             if self.request.user.is_authenticated:
                 scheme, identifier = self.request.user.username.split(":")
-                return _get_or_404(ibis.get_person_methods().getPerson(scheme, identifier, fetch))
             else:
                 raise Http404("You are not authenticated")
 


### PR DESCRIPTION
Also includes a mockup service that will return the test lookup user mug99 when the scheme="mock". It still needs to modify the consent app to use scheme "mock" when using test raven.

closes #11 