### PR TITLE
lookupproxy: allow trailing slash in ui URL

### DIFF
--- a/lookupproxy/urls.py
+++ b/lookupproxy/urls.py
@@ -36,7 +36,7 @@ urlpatterns = [
     path('status', automationcommon.views.status, name='status'),
 
     path('', include('lookupapi.urls')),
-    path('ui', schema_view.with_ui('swagger', cache_timeout=None), name='schema-swagger-ui'),
+    path('ui/', schema_view.with_ui('swagger', cache_timeout=None), name='schema-swagger-ui'),
 ]
 
 # Selectively enable django debug toolbar URLs. Only if the toolbar is


### PR DESCRIPTION
The IAR backend allows both /ui and /ui/ for the swagger UI URLs. We
should be consistent.