### PR TITLE
DO NOT MERGE: refresh Dockerfile a little

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.6
+FROM uisautomation/django:2.0-py3.6
+RUN apk add --no-cache bash
 
 WORKDIR /usr/src/app
 
@@ -8,4 +9,4 @@ RUN pip install -r ./requirements_docker.txt
 ADD ./ /usr/src/app/
 
 ENV DJANGO_SETTINGS_MODULE=lookupproxy.settings.docker
-ENTRYPOINT ["scripts/docker-entrypoint.sh"]
+ENTRYPOINT ["./scripts/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -20,3 +20,12 @@ This application ships with a basic packaging using Docker. It makes use of
 container is configured to use lookupproxy.settings.docker by default as the
 Django settings. In use you probably want to override this with a settings
 module which includes at least the OAuth2 configuration and SECRET_KEY setting.
+
+The following environment variables are mapped to the corresponding Django
+settings:
+
+* ``OAUTH2_TOKEN_URL``
+* ``OAUTH2_INTROSPECT_URL``
+* ``OAUTH2_CLIENT_ID``
+* ``OAUTH2_CLIENT_SECRET``
+* ``OAUTH2_INTROSPECT_SCOPES`` (scopes should be separated by spaces)

--- a/lookupproxy/settings/docker.py
+++ b/lookupproxy/settings/docker.py
@@ -1,4 +1,5 @@
 from .base import *  # noqa: F403
+import os
 
 DEBUG = False
 ALLOWED_HOSTS = ['*']
@@ -11,3 +12,39 @@ MIDDLEWARE = [
 
 # In production, use the production lookup
 LOOKUP_API_ENDPOINT_HOST = 'www.lookup.cam.ac.uk'
+
+# Load OAuth2 settings from environment if present
+OAUTH2_TOKEN_URL = os.environ.get('OAUTH2_TOKEN_URL', None)
+OAUTH2_INTROSPECT_URL = os.environ.get('OAUTH2_INTROSPECT_URL', None)
+OAUTH2_CLIENT_ID = os.environ.get('OAUTH2_CLIENT_ID', None)
+OAUTH2_CLIENT_SECRET = os.environ.get('OAUTH2_CLIENT_SECRET', None)
+OAUTH2_INTROSPECT_SCOPES = os.environ.get('OAUTH2_INTROSPECT_SCOPES', '').split(' ')
+
+# Logging
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'verbose': {
+            'format': ('%(levelname)s %(asctime)s %(pathname)s:%(lineno)d '
+                       '%(funcName)s "%(message)s"')
+        },
+        'simple': {
+            'format': '%(levelname)s "%(message)s"'
+        },
+    },
+    'handlers': {
+        'console': {
+            'level': 'INFO',
+            'class': 'logging.StreamHandler',
+            'formatter': 'verbose',
+        },
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console'],
+            'propagate': True,
+            'level': 'INFO'
+        },
+    }
+}


### PR DESCRIPTION
> **DO NOT MERGE:** This PR is for discussion.

As noted in #25, our production Dockerfile is not as flexible as it could be. Enable configuration or OAUTH2_... settings via environment variables and add our logging configuration.

Update the Dockerfile to be based on our common images.

I've tagged this as DO NOT MERGE because we do not currently have a test infrastructure for lookupproxy so I'm loathe to merge such a fundamental modification to the Dockerfile without some test deployment to check first.