### PR TITLE
lookupapi: support users not of the form {scheme}:{identifier}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ sudo: required
 services:
   - docker
 
+addons:
+  postgresql: "9.6"
+
 language: python
 
 # This should match the version run by tox.

--- a/lookupapi/views.py
+++ b/lookupapi/views.py
@@ -131,7 +131,16 @@ class Person(ViewPermissionsMixin, generics.RetrieveAPIView):
 
         if scheme == "token" and identifier == "self":
             if self.request.user.is_authenticated:
-                scheme, identifier = self.request.user.username.split(":")
+                # Historically we have used both ':' and '+' as a record separator in usernames to
+                # record scheme and identifier. We have also used bare crsids. Attempt to support
+                # all of these things.
+                username = self.request.user.username
+                if ':' in username:
+                    scheme, identifier = username.split(':')
+                elif '+' in username:
+                    scheme, identifier = username.split('+')
+                else:
+                    scheme, identifier = 'crsid', username
             else:
                 raise Http404("You are not authenticated")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Requirements for the webapp itself
 django>=2.0
-psycopg2
+psycopg2-binary
 # explicitly specify django-automationcommon's git repo since changes in
 # automationcommon tend to be "ad hoc" and may need testing here without a
 # corresponding pypi release. Recall that git branched may be explicitly given


### PR DESCRIPTION
> This change is currently deployed to the live service since otherwise the IAR is broken.

Lookupapi still had the implicit assumption that users would be named {scheme}:{identifier} when created by django-automationoauth. That is no-longer true and caused lookup proxy to fail when re-deployed.

With an abundance of caution, make sure we support all schemes we have used historically until we're sure nothing will break if we remove them.

Additionally, fix build errors on tox by making use of the psychopg2-binary package.